### PR TITLE
#82 Bug: 'tailwindcss' import causes an error and is unneeded

### DIFF
--- a/app/static/globals.css
+++ b/app/static/globals.css
@@ -1,5 +1,3 @@
-@import "tailwindcss";
-
 :root {
     --primary: #8E4DE4;
     --secondary: #5D05EA;


### PR DESCRIPTION
This pr simply removes the import 'tailwindcss' statement at the top of globals.css as it was causing a console error and was unused.

Note: This does not mean TailwindCSS has been removed from the tech stack (the CDN is imported for all of the html templates so it is fully in use)