### PR TITLE
Add .flaskenv file to fix the flask CLI problem

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,3 @@
+# Force Flask CLI to import run.py
+# Required so Flask-Migrate is initialized and `flask db` commands work
+FLASK_APP=run:app


### PR DESCRIPTION
Bug Cause:
- Flask-Migrate is initialized in run.py instead of inside the factory method (required in the lecture)
- Flask CLI was auto-detecting and loading app:create_app directly, which skipped the migration initialization in run.py. Therefore, flask db commands were unavailable.

Fix: 
- Added a .flaskenv file with:
- FLASK_APP=run:app

So that Flask CLI loads the deployment app from run.py, ensuring Flask-Migrate is initialized correctly before running migration commands