### PR TITLE
Issue 110 leaderboard tests

### DIFF
--- a/app/templates/leaderboard.html
+++ b/app/templates/leaderboard.html
@@ -63,7 +63,7 @@
                     <i class="fa fa-trophy text-6xl text-[var(--primary)] mb-4 opacity-30"></i>
                     <p class="text-[var(--secondary)] text-xl mb-2">No scores yet!</p>
                     <p class="text-[var(--secondary)] opacity-60">Be the first to set a high score.</p>
-                    <a href="{{ url_for('play') }}">
+                    <a href="{{ url_for('game.play') }}">
                         <div class="inline-block mt-6 px-8 py-3 bg-[var(--primary)] hover:scale-105 rounded-2xl text-lg font-bold shadow-[0_0_1rem_var(--secondary)] transition cursor-pointer">
                             Play Now!
                         </div>

--- a/app/tests/selenium/test_leaderboard_selenium.py
+++ b/app/tests/selenium/test_leaderboard_selenium.py
@@ -1,0 +1,194 @@
+import threading # Use threading instead of multiprocessing to avoid Flask app pickling issues on macOS/Python 3.14
+import time
+from unittest import TestCase
+
+from app import create_app, db
+from app.config import TestConfig
+from app.models import Account, Profile, BestStats
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
+
+
+localHost = "http://127.0.0.1:5000/"
+
+
+class LeaderboardSeleniumTests(TestCase):
+
+    def setUp(self):
+        self.testApp = create_app(TestConfig)
+        self.app_context = self.testApp.app_context()
+        self.app_context.push()
+
+        db.create_all()
+
+        self.server_thread = threading.Thread(
+            target=self.testApp.run,
+            kwargs={
+                "host": "127.0.0.1",
+                "port": 5000,
+                "use_reloader": False
+            }
+        )
+
+        self.server_thread.daemon = True
+        self.server_thread.start()
+
+        time.sleep(1)
+
+        options = Options()
+        options.add_argument("--headless=new")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        options.add_argument("--disable-gpu")
+
+        self.driver = webdriver.Chrome(options=options)
+
+        return super().setUp()
+
+    def tearDown(self):
+
+        if hasattr(self, "driver"):
+            self.driver.quit()
+
+        if hasattr(self, "server_thread"):
+            
+            self.server_thread.join(timeout=1) # lets the thread clean up properly,prevents leftover background threads
+
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+        return super().tearDown()
+
+    # Helper function to create leaderboard players
+    def create_player(self, email, username, score):
+
+        account = Account(
+            email=email,
+            friend_code=username[:8].upper(),
+            is_email_verified=True
+        )
+
+        account.set_password("password123")
+
+        db.session.add(account)
+        db.session.commit()
+
+        profile = Profile(
+            id=account.id,
+            username=username
+        )
+
+        stats = BestStats(
+            id=account.id,
+            highscore=score,
+            longest_time=10.0,
+            jump_count=5,
+            currency=0,
+            total_games=1
+        )
+
+        db.session.add(profile)
+        db.session.add(stats)
+        db.session.commit()
+
+    # Purpose:
+    # Test that leaderboard page opens successfully.
+    # Expected:
+    # The page loads and displays the leaderboard heading.
+    def test_leaderboard_page_loads(self):
+
+        self.driver.get(localHost + "leaderboard")
+
+        self.assertIn(
+            "Leaderboard",
+            self.driver.page_source
+        )
+
+    # Purpose:
+    # Test that leaderboard displays player username and score.
+    # Expected:
+    # Player username and score appear on the page.
+    def test_leaderboard_displays_player_score(self):
+
+        self.create_player(
+            email="player@example.com",
+            username="PlayerOne",
+            score=500
+        )
+
+        self.driver.get(localHost + "leaderboard")
+
+        self.assertIn(
+            "PlayerOne",
+            self.driver.page_source
+        )
+
+        self.assertIn(
+            "500",
+            self.driver.page_source
+        )
+
+    # Purpose:
+    # Test leaderboard ranking order.
+    # Expected:
+    # Higher score player appears before lower score player.
+    def test_leaderboard_ranking_order(self):
+
+        self.create_player(
+            email="low@example.com",
+            username="LowScore",
+            score=100
+        )
+
+        self.create_player(
+            email="high@example.com",
+            username="HighScore",
+            score=900
+        )
+
+        self.driver.get(localHost + "leaderboard")
+
+        page_source = self.driver.page_source
+
+        self.assertLess(
+            page_source.index("HighScore"),
+            page_source.index("LowScore")
+        )
+    
+    # Purpose:
+    # Test navigation from home page to leaderboard page.
+    # Expected:
+    # Clicking the Leaderboard link opens the leaderboard page.
+    def test_home_to_leaderboard_navigation(self):
+
+        self.driver.get(localHost)
+
+        self.driver.find_element(By.LINK_TEXT, "Leaderboard").click()
+
+        self.assertIn(
+            "/leaderboard",
+            self.driver.current_url
+        )
+
+        self.assertIn(
+            "Leaderboard",
+            self.driver.page_source
+        )
+
+    # Purpose:
+    # Test game navigation from leaderboard page.
+    # Expected:
+    # Clicking Play Now opens the game page.
+    def test_leaderboard_start_playing_navigation(self):
+
+        self.driver.get(localHost + "leaderboard")
+
+        self.driver.find_element(By.LINK_TEXT, "Play Now!").click()
+
+        self.assertIn(
+            "/play",
+            self.driver.current_url
+        )

--- a/app/tests/unit/test_leaderboard.py
+++ b/app/tests/unit/test_leaderboard.py
@@ -1,0 +1,58 @@
+from app.tests.test_config import BaseTestCase
+from app import db
+from app.models import Account, Profile, BestStats
+
+
+class LeaderboardTestCase(BaseTestCase):
+
+    # Helper function to create a user with score data
+    def create_player(self, email, username, score):
+        account = Account(
+            email=email,
+            friend_code=username[:8].upper(),
+            is_email_verified=True
+        )
+        account.set_password("password123")
+
+        db.session.add(account)
+        db.session.commit()
+
+        profile = Profile(
+            id=account.id,
+            username=username
+        )
+
+        stats = BestStats(
+            id=account.id,
+            highscore=score,
+            longest_time=10.0,
+            jump_count=5,
+            currency=0,
+            total_games=1
+        )
+
+        db.session.add(profile)
+        db.session.add(stats)
+        db.session.commit()
+
+        return account
+
+    # Test leaderboard page loads successfully
+    def test_leaderboard_page_loads(self):
+        response = self.client.get("/leaderboard")
+
+        self.assertEqual(response.status_code, 200)
+
+    # Test leaderboard displays player username and score
+    def test_leaderboard_displays_player_score(self):
+        self.create_player(
+            email="player@example.com",
+            username="PlayerOne",
+            score=500
+        )
+
+        response = self.client.get("/leaderboard")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"PlayerOne", response.data)
+        self.assertIn(b"500", response.data)

--- a/app/tests/unit/test_leaderboard.py
+++ b/app/tests/unit/test_leaderboard.py
@@ -56,3 +56,35 @@ class LeaderboardTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"PlayerOne", response.data)
         self.assertIn(b"500", response.data)
+
+    # Test that leaderboard ranks higher scores before lower scores
+    def test_leaderboard_orders_scores_highest_first(self):
+
+        # Create player with lower score
+        self.create_player(
+            email="low@example.com",
+            username="LowScore",
+            score=100
+        )
+
+        # Create player with higher score
+        self.create_player(
+            email="high@example.com",
+            username="HighScore",
+            score=900
+        )
+
+        # Request leaderboard page
+        response = self.client.get("/leaderboard")
+
+        # Check page loads successfully
+        self.assertEqual(response.status_code, 200)
+
+        # Convert HTML response into readable text
+        page_text = response.data.decode()
+
+        # Verify higher score player appears before lower score player
+        self.assertLess(
+            page_text.index("HighScore"),
+            page_text.index("LowScore")
+        )

--- a/app/tests/unit/test_leaderboard.py
+++ b/app/tests/unit/test_leaderboard.py
@@ -59,7 +59,6 @@ class LeaderboardTestCase(BaseTestCase):
 
     # Test that leaderboard ranks higher scores before lower scores
     def test_leaderboard_orders_scores_highest_first(self):
-
         # Create player with lower score
         self.create_player(
             email="low@example.com",
@@ -88,3 +87,15 @@ class LeaderboardTestCase(BaseTestCase):
             page_text.index("HighScore"),
             page_text.index("LowScore")
         )
+
+    # Test leaderboard handles empty score list correctly
+    def test_empty_leaderboard_page_loads(self):
+
+        # Request leaderboard page with no players added
+        response = self.client.get("/leaderboard")
+
+        # Check page still loads successfully
+        self.assertEqual(response.status_code, 200)
+
+        # Verify leaderboard page content appears
+        self.assertIn(b"Leaderboard", response.data)


### PR DESCRIPTION
## Changes Made
* Added unit tests for leaderboard functionality
* Added Selenium tests for leaderboard browser interactions
* Tested leaderboard page loading and accessibility
* Tested player score display and ranking order
* Tested navigation from home page to leaderboard
* Tested navigation from leaderboard to game page
* Fixed incorrect Flask endpoint reference in leaderboard template (`url_for('play')` → `url_for('game.play')`)

## Test Coverage
### Unit Tests
* Leaderboard page loads correctly
* High score data displays correctly
* Leaderboard rankings display correctly
* Empty leaderboard handling

### Selenium Tests
* Leaderboard page opens in browser
* Leaderboard content displays correctly
* Navigation from home page to leaderboard works
* Navigation from leaderboard to play page works

## Notes
* Used `threading.Thread` instead of `multiprocessing.Process` for Selenium server setup to avoid Flask pickling issues on macOS/Python 3.14.
