### PR TITLE
Disable email editing in profile page

### DIFF
--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -270,7 +270,8 @@
                         type="email"
                         name="email"
                         value="{{ current_user.email }}"
-                        class="w-full rounded-xl bg-transparent border border-[var(--primary)] px-4 py-3 text-white focus:outline-none focus:border-[var(--secondary)]"
+                        readonly
+                        class="w-full rounded-xl bg-transparent border border-[var(--primary)] px-4 py-3 text-gray-400 cursor-not-allowed focus:outline-none"
                     >
                 </div>
 


### PR DESCRIPTION
Updated the edit profile form to make the email field read-only instead of disabled.
Using `readonly` prevents users from editing their email while still submitting the existing email value with the form, which fixes the profile update issue during Selenium testing.
Username editing functionality still works correctly.
