### PR TITLE
Restrict profile editing to username only in backend

### DIFF
--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -29,13 +29,9 @@ def profile():
             # Save profile form after validation
             if editForm.validate_on_submit():
 
-                # Remove extra spaces from inputs
+                # Remove extra spaces from username input
                 username = editForm.username.data.strip()
-                email = editForm.email.data.strip().lower()
-
-                # Update account email
-                current_user.email = email
-
+                
                 # New user without a profile yet
                 if not current_user.profile:
                     profile = Profile(id=current_user.id,username=username)

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -253,19 +253,12 @@
                     >
                 </div>
 
-                <div>
-                    <label class="block text-[var(--secondary)] mb-2">
-                        Email
-                    </label>
-                    <input
-                        type="email"
-                        name="email"
-                        value="{{ current_user.email }}"
-                        readonly
-                        class="w-full rounded-xl bg-transparent border border-[var(--primary)] px-4 py-3 text-gray-400 cursor-not-allowed focus:outline-none"
-                    >
-                </div>
-
+                <input
+                    type="hidden"
+                    name="email"
+                    value="{{ current_user.email }}"
+                >
+                
                 <div class="flex flex-col md:flex-row justify-center gap-4 pt-4">
                     <button type="submit" class="bg-[var(--primary)] text-white px-6 py-3 rounded-2xl text-center shadow-[0_0_20px_var(--secondary)] hover:opacity-90 transition">
                         Save Changes


### PR DESCRIPTION
Updated the backend profile editing logic so users can only update their username.

Removed backend email update handling from the profile route to prevent account email changes through profile edit requests. Existing username editing functionality remains unchanged.